### PR TITLE
Add test dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
  - "ssh localhost true"
 
 # Run tests
-script: "bin/cylc test-battery -- -j 1"
+script: "bin/cylc test-battery -- -j 2"
 
 # Print results
 after_script: 


### PR DESCRIPTION
Install `at` and a localhost ssh key on the test runner

Running with `-j 2` seems like a good starting point on Travis - when it's 4 more tests are failing (presumably due to timeouts), when it's 1 it takes over 40 min to run the tests.
