### PR TITLE
Add a store for CLI variables for reload, which can then be accessed

### DIFF
--- a/cylc/flow/scripts/reload.py
+++ b/cylc/flow/scripts/reload.py
@@ -60,11 +60,24 @@ from cylc.flow.network.multi import call_multi
 from cylc.flow.option_parsers import (
     WORKFLOW_ID_MULTI_ARG_DOC,
     CylcOptionParser as COP,
+    OptionSettings,
 )
 from cylc.flow.terminal import cli_function
 
 if TYPE_CHECKING:
     from optparse import Values
+
+
+RELOAD_OPTIONS = [
+    OptionSettings(
+        ['-g', '--global'],
+        help='also reload global configuration.',
+        action="store_true",
+        default=False,
+        dest="reload_global",
+        sources={'reload'}
+    ),
+]
 
 
 MUTATION = '''
@@ -89,11 +102,8 @@ def get_option_parser():
         multiworkflow=True,
         argdoc=[WORKFLOW_ID_MULTI_ARG_DOC],
     )
-
-    parser.add_option(
-        "-g", "--global",
-        help="also reload global configuration.",
-        action="store_true", default=False, dest="reload_global")
+    for option in RELOAD_OPTIONS:
+        parser.add_option(*option.args, **option.kwargs)
 
     return parser
 

--- a/cylc/flow/scripts/validate_reinstall.py
+++ b/cylc/flow/scripts/validate_reinstall.py
@@ -73,6 +73,7 @@ from cylc.flow.scripts.reinstall import (
     reinstall_cli as cylc_reinstall,
 )
 from cylc.flow.scripts.reload import (
+    RELOAD_OPTIONS,
     run as cylc_reload
 )
 from cylc.flow.terminal import cli_function
@@ -86,6 +87,7 @@ VR_OPTIONS = combine_options(
     VALIDATE_OPTIONS,
     REINSTALL_OPTIONS,
     REINSTALL_CYLC_ROSE_OPTIONS,
+    RELOAD_OPTIONS,
     PLAY_OPTIONS,
     CYLC_ROSE_OPTIONS,
     modify={'cylc-rose': 'validate, install'}
@@ -102,6 +104,7 @@ def get_option_parser() -> COP:
     for option in VR_OPTIONS:
         parser.add_option(*option.args, **option.kwargs)
     parser.set_defaults(is_validate=True)
+
     return parser
 
 


### PR DESCRIPTION
Hi @ScottWales 

This should fix the test failure in https://github.com/cylc/cylc-flow/pull/6509/files. 

### What's going on

When I wrote VIP I wrote a wierd infrastructure around sharing and combining CLI arguments. You hadn't shared your new CLI argument with `cylc vr`, which uses reload leading to a `ValueError` when reload tried to access `options.reload_global` and it wasn't there.